### PR TITLE
When HTTP 409 is returned, it is somehow normal

### DIFF
--- a/src/slipstream/api/api.py
+++ b/src/slipstream/api/api.py
@@ -1053,6 +1053,10 @@ class Api(object):
         data = {"n": quantity} if quantity else None
 
         response = self.session.post(url, data=data)
+  
+        if response.status_code == 409:
+            reason = etree.fromstring(response.text).get('detail')
+            raise SlipStreamError(reason)
 
         response.raise_for_status()
 
@@ -1078,6 +1082,10 @@ class Api(object):
         url = '%s/run/%s/%s' % (self.endpoint, str(deployment_id), str(node_name))
 
         response = self.session.delete(url, data={"ids": ",".join(str(id_) for id_ in ids)})
+  
+        if response.status_code == 409:
+            reason = etree.fromstring(response.text).get('detail')
+            raise SlipStreamError(reason)
 
         response.raise_for_status()
 


### PR DESCRIPTION
The error means that the deployment can't be scalled at the moment, I think it should just raise a SlipStreamError